### PR TITLE
Allow multiple picks in a row

### DIFF
--- a/edropper2.js
+++ b/edropper2.js
@@ -144,8 +144,9 @@ var page = {
       return;
 
     e.preventDefault();
-
-    page.dropperDeactivate();
+	
+	if (e.shiftKey!=1)
+		page.dropperDeactivate();
     page.sendMessage({type: "set-color", color: page.pickColor(e)});
   },
 


### PR DESCRIPTION
Disable the dropper if shift key is not pressed. If it is pressed, allow
the user to pick another color.
