### PR TITLE
Hid overflow and extra scrollbar on settings page

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -20,6 +20,10 @@
             .donate-button:hover {
                 color: white;
             }
+            
+            body {
+                overflow-x: hidden;   
+            }
         </style>
     </head>
 


### PR DESCRIPTION
Added css to hide the overflow on the X axis of the page, preventing an extra scrollbar.

Before:
![Before](https://i.imgur.com/hSssibK.png)
After:
![After](https://i.imgur.com/EgliBBi.png)