### PR TITLE
Adding github action for automated submission + dependabot upkeep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "19:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,24 @@
+name: automerge
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+  automerge:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,24 @@
+name: Submit extension
+
+on:
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 
+      with:
+        path: source
+    - run: mkdir archives
+    - name: Install, build, zip
+      run: |
+        cd source
+        npm ci
+        npm run build:prod
+        npm run zip:prod
+    - name: Browser Plugin Publish
+      uses: plasmo-corp/bpp@v1
+      with:
+        artifact: "archives/EyeDropper_{version}.zip"
+        keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 yarn-error.log
 .log/*
 size-plugin.json
+keys.json


### PR DESCRIPTION
Hi @kepi ,

Thanks for making eye dropper - it's been fun to use :D I was looking for ways to contribute, and found that since your codebase doesn't have continuous integration, I thought adding that might be helpful. 

I created a 2 workflows in this PR:

- `automerge`: automate the dependabot merging to reduce PR noise, using https://github.com/fastify/github-action-merge-dependabot
- `submit`: automate the zip submission process to the Chrome/Firefox/Edge stores automatically, using [bpp](https://browser.market) . It is set to run manually from the github action tab, but we can tweak it to run as frequent as you wish! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

The `SUBMIT_KEYS` secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)